### PR TITLE
Adding time to the log file name to prevent overwrites

### DIFF
--- a/app.js
+++ b/app.js
@@ -65,7 +65,7 @@ function delete_old(file) {
 
 function proceed(file) {
   var final_name = file.substr(0, file.length - 4) + '__'
-    + moment().subtract(1, durationLegend[INTERVAL_UNIT]).format(DATE_FORMAT.substring(0, DATE_FORMAT.lastIndexOf(INTERVAL_UNIT)+2)) + '.log';
+    + moment().subtract(1, durationLegend[INTERVAL_UNIT]).format(DATE_FORMAT) + '.log';
 
 	var readStream = fs.createReadStream(file);
 	var writeStream = fs.createWriteStream(final_name);


### PR DESCRIPTION
If a log flies size crosses max_size value more than once a day, currently the log file gets overwritten, when interval_unit is set to DD (this is also the default).

So, isn't it better to always name a file along with the time ?