### PR TITLE
Fixed logic in is_it_time_yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ There are 3 values that you need to configure :
 - interval (Defaults to 1):
 - interval_unit (Defaults to 'DD'): interval and interval_unit works together, it means if you have interval_unit='DD' and interval=3, it will split the logs every 3 days.
 - retain (Defaults to all): This number is the number of rotated logs that are keep at any one time, it means that if you have retain = 7 you will have at most 7 rotated logs and your current one.
+- file_name_date (Defaults to 'old'): Specify how to name the rotated files. 'old' will use the previous criteria (current time minus 1 interval_unit), 'current' will use the log rotation time.
 
 Possible values for interval_unit are 'MM' (months), 'DD' (days), 'mm' (minutes).
 eg: interval:9, interval_unit:'mm' will split the logs every 9 minutes.

--- a/app.js
+++ b/app.js
@@ -121,7 +121,7 @@ function proceed_app(app, force) {
 
 function is_it_time_yet() {
   var NOW = moment().startOf(MOMENT_UNIT);
-  if (NOW.diff(BEGIN, MOMENT_UNIT) > INTERVAL) {
+  if (NOW.diff(BEGIN, MOMENT_UNIT) >= INTERVAL) {
 	  BEGIN = NOW;
 	  return true;
   }

--- a/app.js
+++ b/app.js
@@ -32,13 +32,16 @@ var INTERVAL_UNIT = conf.interval_unit || 'DD'; // MM = months, DD = days, mm = 
 var INTERVAL = parseInt(conf.interval) || 1; // INTERVAL:1 day
 var RETAIN = isNaN(parseInt(conf.retain))? undefined: parseInt(conf.retain); // All
 
-var NOW = parseInt(moment().format(INTERVAL_UNIT));
+
 var DATE_FORMAT = 'YYYY-MM-DD-HH-mm';
 var durationLegend = {
   MM: 'M',
   DD: 'd',
   mm: 'm'
 };
+
+var MOMENT_UNIT = durationLegend[INTERVAL_UNIT];
+var BEGIN = moment().startOf(MOMENT_UNIT);
 
 var gl_file_list = [];
 
@@ -79,7 +82,7 @@ function delete_old(file) {
 
 function proceed(file) {
   var final_name = file.substr(0, file.length - 4) + '__'
-    + moment().subtract(1, durationLegend[INTERVAL_UNIT]).format(DATE_FORMAT) + '.log';
+    + moment().subtract(1, MOMENT_UNIT).format(DATE_FORMAT) + '.log';
 
 	var readStream = fs.createReadStream(file);
 	var writeStream = fs.createWriteStream(final_name, {'flags': 'a'});
@@ -117,15 +120,13 @@ function proceed_app(app, force) {
 }
 
 function is_it_time_yet() {
-  var max_value = INTERVAL_UNIT == 'MM' ? 12 : 60;
-
-  if (NOW + INTERVAL == parseInt(moment().format(INTERVAL_UNIT))
-      || NOW + INTERVAL == parseInt(moment().format(INTERVAL_UNIT)) - max_value) {
-    NOW = parseInt(moment().format(INTERVAL_UNIT));
-    return true;
+  var NOW = moment().startOf(MOMENT_UNIT);
+  if (NOW.diff(BEGIN, MOMENT_UNIT) > INTERVAL) {
+	  BEGIN = NOW;
+	  return true;
   }
   else {
-    return false;
+	  return false;
   }
 }
 

--- a/app.js
+++ b/app.js
@@ -31,7 +31,7 @@ var SIZE_LIMIT = get_limit_size(); // 10MB
 var INTERVAL_UNIT = conf.interval_unit || 'DD'; // MM = months, DD = days, mm = minutes
 var INTERVAL = parseInt(conf.interval) || 1; // INTERVAL:1 day
 var RETAIN = isNaN(parseInt(conf.retain))? undefined: parseInt(conf.retain); // All
-
+var FILE_NAME_DATE = conf.file_name_date || 'old';
 
 var DATE_FORMAT = 'YYYY-MM-DD-HH-mm';
 var durationLegend = {
@@ -81,8 +81,14 @@ function delete_old(file) {
 }
 
 function proceed(file) {
+  var file_name_date = moment();
+  
+  if (FILE_NAME_DATE === 'old') {
+	  file_name_date.subtract(1, MOMENT_UNIT);
+  }
+   
   var final_name = file.substr(0, file.length - 4) + '__'
-    + moment().subtract(1, MOMENT_UNIT).format(DATE_FORMAT) + '.log';
+    + file_name_date.format(DATE_FORMAT) + '.log';
 
 	var readStream = fs.createReadStream(file);
 	var writeStream = fs.createWriteStream(final_name, {'flags': 'a'});


### PR DESCRIPTION
This should fix the issues described here: https://github.com/pm2-hive/pm2-logrotate/issues/15
is_it_time_yet  now uses momentjs' diff to decide if enough time has passed and a time based rotation is needed. The base time is calculated using momentjs' startOf and the supplied timeunit to mimic the original behavior.
