### PR TITLE
Allow 2 character unit in max_value size

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ PM2 module to automatically rotate logs of processes managed by PM2.
 
 ## Configure
 
-- `max_size` (Defaults to `10MB`): When a file size becomes higher than this value it will rotate it (its possible that the worker check the file after it actually pass the limit) . You can specify the unit at then end: `10G`, `10M`, `10K`
+- `max_size` (Defaults to `10M`): When a file size becomes higher than this value it will rotate it (its possible that the worker check the file after it actually pass the limit) . You can specify the unit at then end: `10G`, `10M`, `10K`
 - `retain` (Defaults to `all`): This number is the number of rotated logs that are keep at any one time, it means that if you have retain = 7 you will have at most 7 rotated logs and your current one.
 - `compress` (Defaults to `false`): Enable compression via gzip for all rotated logs
 - `dateFormat` (Defaults to `YYYY-MM-DD_HH-mm-ss`) : Format of the data used the name the file of log

--- a/app.js
+++ b/app.js
@@ -51,11 +51,11 @@ function get_limit_size() {
     return (1024 * 1024 * 10);
   if (typeof(conf.max_size) !== 'string')
       conf.max_size = conf.max_size + "";
-  if (conf.max_size.slice(-1) === 'G')
+  if (conf.max_size.slice(-2).toLowerCase().indexOf('g') > -1)
     return (parseInt(conf.max_size) * 1024 * 1024 * 1024);
-  if (conf.max_size.slice(-1) === 'M')
+  if (conf.max_size.slice(-2).toLowerCase().indexOf('m') > -1)
     return (parseInt(conf.max_size) * 1024 * 1024);
-  if (conf.max_size.slice(-1) === 'K')
+  if (conf.max_size.slice(-2).toLowerCase().indexOf('k') > -1)
     return (parseInt(conf.max_size) * 1024);
   return parseInt(conf.max_size);
 }


### PR DESCRIPTION
I ran into the same issue as reported in #46 and it wasn't clear why the logs were being overwritten every 30 seconds. I think it makes sense to make the unit less strict. Alternatively, I would just change the README.md file so that the default value is in the correct format.