### PR TITLE
Correctly set scope to pmx and not this

### DIFF
--- a/app.js
+++ b/app.js
@@ -107,10 +107,10 @@ function proceed(file) {
   
 
   // listen for error
-  readStream.on('error', pmx.notify.bind(this))
-  writeStream.on('error', pmx.notify.bind(this))
+  readStream.on('error', pmx.notify.bind(pmx))
+  writeStream.on('error', pmx.notify.bind(pmx))
   if (COMPRESSION) {
-    GZIP.on('error', pmx.notify.bind(this))
+    GZIP.on('error', pmx.notify.bind(pmx))
   }
 
  // when the read is done, empty the file and check for retain option


### PR DESCRIPTION
this._interpretError is still not found because it is now searching for it on pm2-logrotate
but should search for it on pmx

This still happens with 2.2.3

```
TypeError: this._interpretError is not a function
    at Notify.notify (/home/researchgate/tor_prd/.pm2_community_green/node_modules/pmx/lib/notify.js:112:22)
    at emitOne (events.js:115:13)
    at Gzip.emit (events.js:210:7)
    at done (_stream_transform.js:205:19)
    at _flush (_stream_transform.js:138:7)
    at Gzip._transform (zlib.js:370:12)
    at Gzip._flush (zlib.js:302:8)
    at Gzip.prefinish (_stream_transform.js:137:10)
    at emitNone (events.js:105:13)
    at Gzip.emit (events.js:207:7)

```