### PR TITLE
Allow newer versions of moment-timezone and node-schedule

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "app.js",
   "dependencies": {
     "graceful-fs": "^4.1.11",
-    "moment-timezone": "0.5.5",
-    "node-schedule": "1.1.1",
+    "moment-timezone": "^0.5.11",
+    "node-schedule": "^1.1.1",
     "pm2": "latest",
     "pmx": "latest"
   },


### PR DESCRIPTION
Also requires moment-timezone 0.5.11 minimal to remove a nasty console.log

https://github.com/moment/moment-timezone/issues/231
