### PR TITLE
Added TZ variable to offset rotated log time string

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,6 +42,7 @@ var ROTATE_CRON = conf.rotateInterval || "0 0 * * *"; // default : every day at 
 var RETAIN = isNaN(parseInt(conf.retain)) ? undefined : parseInt(conf.retain); // All
 var COMPRESSION = JSON.parse(conf.compress) || false; // Do not compress by default
 var DATE_FORMAT = conf.dateFormat || 'YYYY-MM-DD_HH-mm-ss';
+var TZ = conf.TZ;
 var ROTATE_MODULE = JSON.parse(conf.rotateModule) || true;
 var WATCHED_FILES = [];
 
@@ -93,8 +94,17 @@ function delete_old(file) {
  * @param {string} file 
  */
 function proceed(file) {
-  var final_name = file.substr(0, file.length - 4) + '__'
-    + moment().format(DATE_FORMAT) + '.log';
+  // set default final time
+  var final_time = moment().format(DATE_FORMAT);
+  // check for a timezone
+  if (TZ) {
+    try {
+      final_time = moment().tz(TZ).format(DATE_FORMAT);
+    } catch(err) {
+      // use default
+    }
+  }
+  var final_name = file.substr(0, file.length - 4) + '__' + final_time + '.log';
   // if compression is enabled, add gz extention and create a gzip instance
   if (COMPRESSION) {
     var GZIP = zlib.createGzip({ level: zlib.Z_BEST_COMPRESSION, memLevel: zlib.Z_BEST_COMPRESSION });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-logrotate",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Module to rotate logs of every pm2 application",
   "main": "app.js",
   "dependencies": {


### PR DESCRIPTION
This PR is to allow offsetting the time using timezones https://github.com/pm2-hive/pm2-logrotate/issues/76.

If my operating system date is UTC / GMT and I want my pm logs to rotate for the starting hour of the logged entries instead of the ending hour, I can specify the timezone to be `Etc/GMT-1` (found on [Wikipedia's List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)) which allows the package `moment-timezone` to subtract one from the hour.

```
./node_modules/.bin/pm2 set pm2-logrotate:TZ 'Etc/GMT-1'
```
