### PR TITLE
Fix inability gunzipping compressed log files

### DIFF
--- a/app.js
+++ b/app.js
@@ -120,7 +120,7 @@ function proceed(file) {
   }
 
  // when the read is done, empty the file and check for retain option
-  readStream.on('end', function() {
+  writeStream.on('finish', function() {
     if (GZIP) {
       GZIP.close();
     }


### PR DESCRIPTION
Fixed https://github.com/pm2-hive/pm2-logrotate/issues/75

From https://github.com/nodejs/node/issues/2485#issuecomment-134312232 it's better to use `writeStream`'s `finish` event instead of `readStream`'s `end` event.