### PR TITLE
Updated README and bumped version to 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@ PM2 module to automatically rotate logs of processes managed by PM2.
 
 ## Install
 
-`pm2 install pm2-logrotate`
+    pm2 install pm2-logrotate
+
+To install a specific version use the `@<version>` suffix
+
+    pm2 install pm2-logrotate@2.2.0
 
 ## Configure
 
-- `max_size` (Defaults to `10MB`): When a file size becomes higher than this value it will rotate it (its possible that the worker check the file after it actually pass the limit) . You can specify the unit at then end: `10G`, `10M`, `10K`
+- `max_size` (Defaults to `10M`): When a file size becomes higher than this value it will rotate it (its possible that the worker check the file after it actually pass the limit) . You can specify the unit at then end: `10G`, `10M`, `10K`
 - `retain` (Defaults to `all`): This number is the number of rotated logs that are keep at any one time, it means that if you have retain = 7 you will have at most 7 rotated logs and your current one.
 - `compress` (Defaults to `false`): Enable compression via gzip for all rotated logs
 - `dateFormat` (Defaults to `YYYY-MM-DD_HH-mm-ss`) : Format of the data used the name the file of log
@@ -17,6 +21,8 @@ PM2 module to automatically rotate logs of processes managed by PM2.
 - `workerInterval` (Defaults to `30` in secs) : You can control at which interval the worker is checking the log's size (minimum is `1`)
 - `rotateInterval` (Defaults to `0 0 * * *` everyday at midnight): This cron is used to a force rotate when executed.
 We are using [node-schedule](https://github.com/node-schedule/node-schedule) to schedule cron, so all valid cron for [node-schedule](https://github.com/node-schedule/node-schedule) is valid cron for this option. Cron style :
+- `TZ` (Defaults to system time): This is the standard [tz database timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) used to offset the log file saved. For instance, a value of `Etc/GMT-1`, with an hourly log, will save a file at hour `14` GMT with hour `13` GMT-1 in the log name.
+
 ```
 *    *    *    *    *    *
 ┬    ┬    ┬    ┬    ┬    ┬
@@ -28,12 +34,13 @@ We are using [node-schedule](https://github.com/node-schedule/node-schedule) to 
 │    └──────────────────── minute (0 - 59)
 └───────────────────────── second (0 - 59, OPTIONAL)
 ```
+
 ### How to set these values ?
 
  After having installed the module you have to type :
 `pm2 set pm2-logrotate:<param> <value>`
 
-e.g: 
+e.g:
 - `pm2 set pm2-logrotate:max_size 1K` (1KB)
 - `pm2 set pm2-logrotate:compress true` (compress logs when rotated)
 - `pm2 set pm2-logrotate:rotateInterval '*/1 * * * *'` (force rotate every minute)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-logrotate",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Module to rotate logs of every pm2 application",
   "main": "app.js",
   "dependencies": {


### PR DESCRIPTION
@vmarchaud sorry for the sloppiness. I forgot to update the README and bump the version.

Also when the version is bumped, is it automatically published to npm? or does the pm2 module system know to update to the latest version on github when I run `pm2 install pm2-logrotate` ? 

Edit: I ran the install command and it installed `2.3.0` which seems to correspond with npm.

```
✗ npm view pm2-logrotate versions
...
  '2.1.1',
  '2.2.0',
  '2.2.2',
  '2.2.3',
  '2.2.4',
  '2.3.0' ]
```

Mind republishing the release on npm? We're about to release and we're hoping to release from your repo than our local repo using the `pm2 install pm2-logrotate`.